### PR TITLE
Add release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create zip package
+        run: |
+          mkdir -p dist
+          zip -r dist/lightwork-wp-plugin.zip . -x '*.git*' -x '*.github*' -x 'dist/*'
+
+      - name: Publish GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/lightwork-wp-plugin.zip"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -164,3 +164,14 @@ Per qualsiasi domanda o problema, apri un **issue** su GitHub o contatta il supp
 
 Questa prima release include una funzionalità di base per la creazione di Custom Post Types tramite una pagina di amministrazione. Dopo l'attivazione, nel menu di WordPress comparirà "LightWork" da cui sarà possibile definire un nuovo CPT specificando slug e label. Il plugin registra automaticamente il CPT e crea un campo ACF denominato "subtitle". Inoltre espone una rotta REST `lightwork/v1/<slug>/` per recuperare gli elementi del tipo creato. È presente un esempio di template nella cartella `templates/` che può essere copiato e adattato nel tema attivo.
 
+
+## Workflow di release
+
+Il repository include un workflow GitHub Actions che crea automaticamente un file `.zip` del plugin e pubblica una release quando viene creato un tag con prefisso `v`.
+
+Per rilasciare una nuova versione:
+
+1. Aggiorna il numero di versione nel file `lightwork-wp-plugin.php`.
+2. Crea un nuovo tag `vX.Y.Z` e spingilo su GitHub.
+
+Il workflow genererà il pacchetto `lightwork-wp-plugin.zip` e lo allegherà alla release corrispondente.

--- a/lightwork-wp-plugin.php
+++ b/lightwork-wp-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: LightWork WP Plugin
  * Description: Gestione dei Custom Post Types integrata con ACF e REST API.
- * Version: 0.1.0
+ * Version: 0.1.1
  * Author: LightWork
  * License: GPLv2 or later
  */


### PR DESCRIPTION
## Summary
- bump plugin version to 0.1.1
- tag commit as `v0.1.1` to trigger release workflow

## Testing
- `php -l lightwork-wp-plugin.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68588bd0c504832fbe4e4bcf9fd317b6