### PR TITLE
Add CPT management interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Il plugin è progettato per essere facilmente configurabile tramite un **wizard 
 
 ### 1. Creazione e gestione di CTP (Custom Post Types)
 - Crea facilmente nuovi **Custom Post Types (CTP)** tramite un'interfaccia semplice e chiara.
+- Pagina di amministrazione con elenco dei CTP creati e azioni di modifica o cancellazione.
+- Creazione guidata personalizzabile (supporti, visibilità, archivio) simile a CPT UI.
 - Gestione completa dei CTP con tutte le opzioni di configurazione, inclusa la visibilità e i permessi.
 - I CTP vengono visualizzati e gestiti nel backend di WordPress in modo intuitivo.
 


### PR DESCRIPTION
## Summary
- implement UI for listing, creating, editing and deleting CPTs
- store additional CPT options and update posts on slug change
- bump plugin version to 0.2.0
- document new admin features

## Testing
- `php -l lightwork-wp-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685902e855a8832fa485d5899f58e337