### PR TITLE
Add ACF field management to CPT editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Descrizione
 
-Il **LightWork-WP-Plugin** per WordPress permette di creare, configurare e gestire facilmente **Custom Post Types (CTP)** personalizzati. Grazie all'integrazione con **Advanced Custom Fields (ACF)**, il plugin offre una soluzione potente sia per gli utenti avanzati che per quelli meno esperti. Consente di creare CTP avanzati, associarvi campi personalizzati, template dinamici e fornisce anche rotte REST per una gestione completamente automatizzata dei dati.
+Il **LightWork-WP-Plugin** per WordPress permette di creare, configurare e gestire facilmente **Custom Post Types (CTP)** personalizzati. Grazie all'integrazione con **Advanced Custom Fields (ACF)**, il plugin offre una soluzione potente sia per gli utenti avanzati che per quelli meno esperti. Consente di creare CTP avanzati, associarvi campi personalizzati, template dinamici e fornisce anche rotte REST per una gestione completamente automatizzata dei dati. Dalla versione 0.3 è possibile aggiungere o rimuovere i campi ACF direttamente dalla schermata di modifica del CTP.
 
 Il plugin è progettato per essere facilmente configurabile tramite un **wizard di amministrazione**, con una gestione automatica delle modifiche dei CTP, senza compromettere la performance del sito. Le rotte REST personalizzate permettono una completa personalizzazione delle query, rendendo il plugin ideale per sviluppatori avanzati e per l'uso su siti con un elevato volume di contenuti.
 
@@ -15,6 +15,8 @@ Il plugin è progettato per essere facilmente configurabile tramite un **wizard 
 - Pagina di amministrazione con elenco dei CTP creati e azioni di modifica o cancellazione.
 - Creazione guidata personalizzabile (supporti, visibilità, archivio) simile a CPT UI.
 - Gestione completa dei CTP con tutte le opzioni di configurazione, inclusa la visibilità e i permessi.
+- Possibilità di definire icona del menu, slug di riscrittura e struttura gerarchica del CTP direttamente dall'interfaccia.
+- I campi ACF possono essere aggiunti o rimossi dal form di modifica del CTP e la modifica si applica a tutti gli elementi esistenti.
 - I CTP vengono visualizzati e gestiti nel backend di WordPress in modo intuitivo.
 
 ### 2. Integrazione con ACF (Advanced Custom Fields)
@@ -33,6 +35,7 @@ Il plugin è progettato per essere facilmente configurabile tramite un **wizard 
 ### 5. Interfaccia wizard per amministratori
 - Una **wizard di configurazione** guida l'amministratore passo passo nel processo di creazione e gestione dei CTP.
 - Gli amministratori possono scegliere facilmente i campi personalizzati da associare ai CTP e configurare i template tramite una semplice interfaccia.
+- La pagina di modifica del CTP consente di gestire l'elenco dei campi ACF collegati, applicando le modifiche a tutte le istanze esistenti.
 
 ### 6. Aggiornamenti massivi dei CTP
 - Il plugin supporta l'aggiornamento di più istanze di un CTP in modalità **batch**.

--- a/lightwork-wp-plugin.php
+++ b/lightwork-wp-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: LightWork WP Plugin
  * Description: Gestione dei Custom Post Types integrata con ACF e REST API.
- * Version: 0.2.0
+ * Version: 0.3.0
  * Author: LightWork
  * License: GPLv2 or later
  */
@@ -45,6 +45,10 @@ class LightWork_WP_Plugin {
         $public      = isset( $args['public'] ) ? (bool) $args['public'] : true;
         $has_archive = isset( $args['has_archive'] ) ? (bool) $args['has_archive'] : true;
         $supports    = isset( $args['supports'] ) && is_array( $args['supports'] ) ? array_map( 'sanitize_key', $args['supports'] ) : [ 'title', 'editor', 'thumbnail' ];
+        $fields       = isset( $args['acf_fields'] ) && is_array( $args['acf_fields'] ) ? $args['acf_fields'] : [];
+        $menu_icon    = isset( $args['menu_icon'] ) ? sanitize_text_field( $args['menu_icon'] ) : '';
+        $rewrite_slug = isset( $args['rewrite_slug'] ) ? sanitize_title_with_dashes( $args['rewrite_slug'] ) : $slug;
+        $hierarchical = isset( $args['hierarchical'] ) ? (bool) $args['hierarchical'] : false;
 
         if ( empty( $slug ) || empty( $single ) || empty( $plural ) ) {
             return;
@@ -67,13 +71,17 @@ class LightWork_WP_Plugin {
             'public'       => $public,
             'show_in_rest' => true,
             'has_archive'  => $has_archive,
-            'rewrite'      => [ 'slug' => $slug ],
+            'rewrite'      => [ 'slug' => $rewrite_slug ],
             'supports'     => $supports,
+            'hierarchical' => $hierarchical,
         ];
+        if ( $menu_icon ) {
+            $args['menu_icon'] = $menu_icon;
+        }
 
         register_post_type( $slug, $args );
 
-        $this->register_acf_fields( $slug );
+        $this->register_acf_fields( $slug, $fields );
     }
 
     /**
@@ -81,22 +89,45 @@ class LightWork_WP_Plugin {
      *
      * @param string $slug Post type slug.
      */
-    private function register_acf_fields( $slug ) {
+    private function register_acf_fields( $slug, array $fields = [] ) {
         if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+            return;
+        }
+
+        if ( empty( $fields ) ) {
+            $fields = [
+                [
+                    'label' => __( 'Subtitle', 'lightwork-wp-plugin' ),
+                    'name'  => 'subtitle',
+                    'type'  => 'text',
+                ],
+            ];
+        }
+
+        $acf_fields = [];
+        foreach ( $fields as $field ) {
+            $name  = sanitize_key( $field['name'] ?? '' );
+            $label = sanitize_text_field( $field['label'] ?? '' );
+            $type  = sanitize_text_field( $field['type'] ?? 'text' );
+            if ( ! $name ) {
+                continue;
+            }
+            $acf_fields[] = [
+                'key'   => 'field_' . $slug . '_' . $name,
+                'label' => $label ?: $name,
+                'name'  => $name,
+                'type'  => $type,
+            ];
+        }
+
+        if ( empty( $acf_fields ) ) {
             return;
         }
 
         acf_add_local_field_group( [
             'key'      => 'group_' . $slug,
             'title'    => ucfirst( $slug ) . ' Fields',
-            'fields'   => [
-                [
-                    'key'   => 'field_' . $slug . '_subtitle',
-                    'label' => __( 'Subtitle', 'lightwork-wp-plugin' ),
-                    'name'  => 'subtitle',
-                    'type'  => 'text',
-                ],
-            ],
+            'fields'   => $acf_fields,
             'location' => [
                 [
                     [
@@ -205,8 +236,12 @@ class LightWork_WP_Plugin {
         $plural      = $cpt['plural'] ?? '';
         $public      = isset( $cpt['public'] ) ? (bool) $cpt['public'] : true;
         $archive     = isset( $cpt['has_archive'] ) ? (bool) $cpt['has_archive'] : true;
-        $supports    = isset( $cpt['supports'] ) && is_array( $cpt['supports'] ) ? $cpt['supports'] : [ 'title', 'editor', 'thumbnail' ];
-        $available   = [ 'title', 'editor', 'thumbnail', 'excerpt', 'custom-fields' ];
+        $supports      = isset( $cpt['supports'] ) && is_array( $cpt['supports'] ) ? $cpt['supports'] : [ 'title', 'editor', 'thumbnail' ];
+        $acf_fields    = isset( $cpt['acf_fields'] ) && is_array( $cpt['acf_fields'] ) ? $cpt['acf_fields'] : [];
+        $menu_icon     = $cpt['menu_icon'] ?? '';
+        $rewrite_slug  = $cpt['rewrite_slug'] ?? $slug;
+        $hierarchical  = isset( $cpt['hierarchical'] ) ? (bool) $cpt['hierarchical'] : false;
+        $available     = [ 'title', 'editor', 'thumbnail', 'excerpt', 'custom-fields' ];
 
         echo '<h2>' . ( $editing ? esc_html__( 'Edit Custom Post Type', 'lightwork-wp-plugin' ) : esc_html__( 'Add Custom Post Type', 'lightwork-wp-plugin' ) ) . '</h2>';
         echo '<form method="post">';
@@ -215,10 +250,36 @@ class LightWork_WP_Plugin {
         echo '<tr><th scope="row"><label for="lw-slug">' . esc_html__( 'Slug', 'lightwork-wp-plugin' ) . '</label></th><td><input name="lw-slug" id="lw-slug" type="text" class="regular-text" value="' . esc_attr( $slug ) . '" required></td></tr>';
         echo '<tr><th scope="row"><label for="lw-single">' . esc_html__( 'Singular Label', 'lightwork-wp-plugin' ) . '</label></th><td><input name="lw-single" id="lw-single" type="text" class="regular-text" value="' . esc_attr( $single ) . '" required></td></tr>';
         echo '<tr><th scope="row"><label for="lw-plural">' . esc_html__( 'Plural Label', 'lightwork-wp-plugin' ) . '</label></th><td><input name="lw-plural" id="lw-plural" type="text" class="regular-text" value="' . esc_attr( $plural ) . '" required></td></tr>';
+        echo '<tr><th scope="row"><label for="lw-menu-icon">' . esc_html__( 'Menu Icon', 'lightwork-wp-plugin' ) . '</label></th><td><input name="lw-menu-icon" id="lw-menu-icon" type="text" class="regular-text" value="' . esc_attr( $menu_icon ) . '" placeholder="dashicons-admin-post" ></td></tr>';
+        echo '<tr><th scope="row"><label for="lw-rewrite-slug">' . esc_html__( 'Rewrite Slug', 'lightwork-wp-plugin' ) . '</label></th><td><input name="lw-rewrite-slug" id="lw-rewrite-slug" type="text" class="regular-text" value="' . esc_attr( $rewrite_slug ) . '"></td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Hierarchical', 'lightwork-wp-plugin' ) . '</th><td><input type="checkbox" name="lw-hierarchical" value="1"' . checked( $hierarchical, true, false ) . ' /></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Supports', 'lightwork-wp-plugin' ) . '</th><td>';
         foreach ( $available as $feature ) {
             echo '<label><input type="checkbox" name="lw-supports[]" value="' . esc_attr( $feature ) . '"' . checked( in_array( $feature, $supports, true ), true, false ) . '/> ' . esc_html( $feature ) . '</label><br />';
         }
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'ACF Fields', 'lightwork-wp-plugin' ) . '</th><td>';
+        echo '<table id="lw-acf-table" class="widefat"><tbody>';
+        if ( ! empty( $acf_fields ) ) {
+            foreach ( $acf_fields as $field ) {
+                $label = esc_attr( $field['label'] ?? '' );
+                $name  = esc_attr( $field['name'] ?? '' );
+                $type  = esc_attr( $field['type'] ?? 'text' );
+                echo '<tr><td>';
+                echo '<input type="text" name="lw-acf-labels[]" placeholder="Label" value="' . $label . '" /> ';
+                echo '<input type="text" name="lw-acf-names[]" placeholder="Name" value="' . $name . '" /> ';
+                echo '<select name="lw-acf-types[]">';
+                $types = [ 'text', 'textarea', 'number', 'image' ];
+                foreach ( $types as $t ) {
+                    echo '<option value="' . esc_attr( $t ) . '"' . selected( $type, $t, false ) . '>' . esc_html( ucfirst( $t ) ) . '</option>';
+                }
+                echo '</select> ';
+                echo '<button type="button" class="button lw-remove-field">&times;</button>';
+                echo '</td></tr>';
+            }
+        }
+        echo '</tbody></table>';
+        echo '<p><button type="button" class="button" id="lw-add-field">' . esc_html__( 'Add Field', 'lightwork-wp-plugin' ) . '</button></p>';
         echo '</td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Public', 'lightwork-wp-plugin' ) . '</th><td><input type="checkbox" name="lw-public" value="1"' . checked( $public, true, false ) . ' /></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Has Archive', 'lightwork-wp-plugin' ) . '</th><td><input type="checkbox" name="lw-archive" value="1"' . checked( $archive, true, false ) . ' /></td></tr>';
@@ -228,6 +289,29 @@ class LightWork_WP_Plugin {
         }
         submit_button( $editing ? __( 'Save Changes', 'lightwork-wp-plugin' ) : __( 'Create CPT', 'lightwork-wp-plugin' ), 'primary', 'lw_save_cpt' );
         echo '</form>';
+        ?>
+        <script>
+        jQuery(function($){
+            $('#lw-add-field').on('click', function(){
+                var row = '<tr><td>' +
+                    '<input type="text" name="lw-acf-labels[]" placeholder="Label" /> ' +
+                    '<input type="text" name="lw-acf-names[]" placeholder="Name" /> ' +
+                    '<select name="lw-acf-types[]">' +
+                        '<option value="text">Text</option>' +
+                        '<option value="textarea">Textarea</option>' +
+                        '<option value="number">Number</option>' +
+                        '<option value="image">Image</option>' +
+                    '</select> ' +
+                    '<button type="button" class="button lw-remove-field">&times;</button>' +
+                    '</td></tr>';
+                $('#lw-acf-table tbody').append(row);
+            });
+            $(document).on('click', '.lw-remove-field', function(){
+                $(this).closest('tr').remove();
+            });
+        });
+        </script>
+        <?php
     }
 
     /**
@@ -239,9 +323,27 @@ class LightWork_WP_Plugin {
         $slug     = isset( $_POST['lw-slug'] ) ? sanitize_key( $_POST['lw-slug'] ) : '';
         $single   = isset( $_POST['lw-single'] ) ? sanitize_text_field( $_POST['lw-single'] ) : '';
         $plural   = isset( $_POST['lw-plural'] ) ? sanitize_text_field( $_POST['lw-plural'] ) : '';
-        $public   = isset( $_POST['lw-public'] );
-        $archive  = isset( $_POST['lw-archive'] );
-        $supports = isset( $_POST['lw-supports'] ) ? array_map( 'sanitize_key', (array) $_POST['lw-supports'] ) : [];
+        $public       = isset( $_POST['lw-public'] );
+        $archive      = isset( $_POST['lw-archive'] );
+        $supports     = isset( $_POST['lw-supports'] ) ? array_map( 'sanitize_key', (array) $_POST['lw-supports'] ) : [];
+        $menu_icon    = isset( $_POST['lw-menu-icon'] ) ? sanitize_text_field( $_POST['lw-menu-icon'] ) : '';
+        $rewrite_slug = isset( $_POST['lw-rewrite-slug'] ) ? sanitize_title_with_dashes( $_POST['lw-rewrite-slug'] ) : $slug;
+        $hierarchical = isset( $_POST['lw-hierarchical'] );
+        $labels   = isset( $_POST['lw-acf-labels'] ) ? (array) $_POST['lw-acf-labels'] : [];
+        $names    = isset( $_POST['lw-acf-names'] ) ? (array) $_POST['lw-acf-names'] : [];
+        $types    = isset( $_POST['lw-acf-types'] ) ? (array) $_POST['lw-acf-types'] : [];
+        $acf_fields = [];
+        foreach ( $names as $index => $name ) {
+            $name = sanitize_key( $name );
+            if ( ! $name ) {
+                continue;
+            }
+            $acf_fields[] = [
+                'label' => sanitize_text_field( $labels[ $index ] ?? $name ),
+                'name'  => $name,
+                'type'  => sanitize_text_field( $types[ $index ] ?? 'text' ),
+            ];
+        }
 
         if ( empty( $slug ) || empty( $single ) || empty( $plural ) ) {
             add_settings_error( 'lightwork', 'invalid', __( 'All fields are required.', 'lightwork-wp-plugin' ) );
@@ -254,12 +356,16 @@ class LightWork_WP_Plugin {
             foreach ( $cpts as &$cpt ) {
                 if ( $cpt['slug'] === $old_slug ) {
                     $cpt = [
-                        'slug'        => $slug,
-                        'single'      => $single,
-                        'plural'      => $plural,
-                        'public'      => $public,
-                        'has_archive' => $archive,
-                        'supports'    => $supports,
+                        'slug'         => $slug,
+                        'single'       => $single,
+                        'plural'       => $plural,
+                        'public'       => $public,
+                        'has_archive'  => $archive,
+                        'supports'     => $supports,
+                        'acf_fields'   => $acf_fields,
+                        'menu_icon'    => $menu_icon,
+                        'rewrite_slug' => $rewrite_slug,
+                        'hierarchical' => $hierarchical,
                     ];
                     if ( $old_slug !== $slug ) {
                         global $wpdb;
@@ -272,12 +378,16 @@ class LightWork_WP_Plugin {
             $message = __( 'Custom Post Type updated.', 'lightwork-wp-plugin' );
         } else {
             $cpts[] = [
-                'slug'        => $slug,
-                'single'      => $single,
-                'plural'      => $plural,
-                'public'      => $public,
-                'has_archive' => $archive,
-                'supports'    => $supports,
+                'slug'         => $slug,
+                'single'       => $single,
+                'plural'       => $plural,
+                'public'       => $public,
+                'has_archive'  => $archive,
+                'supports'     => $supports,
+                'acf_fields'   => $acf_fields,
+                'menu_icon'    => $menu_icon,
+                'rewrite_slug' => $rewrite_slug,
+                'hierarchical' => $hierarchical,
             ];
             $message = __( 'Custom Post Type created.', 'lightwork-wp-plugin' );
         }
@@ -290,6 +400,10 @@ class LightWork_WP_Plugin {
             'public'      => $public,
             'has_archive' => $archive,
             'supports'    => $supports,
+            'acf_fields'  => $acf_fields,
+            'menu_icon'   => $menu_icon,
+            'rewrite_slug'=> $rewrite_slug,
+            'hierarchical'=> $hierarchical,
         ] );
 
         add_settings_error( 'lightwork', 'success', $message, 'updated' );
@@ -363,8 +477,11 @@ class LightWork_WP_Plugin {
                 'title' => get_the_title( $post ),
                 'link'  => get_permalink( $post ),
             ];
-            if ( function_exists( 'get_field' ) ) {
-                $item['subtitle'] = get_field( 'subtitle', $post->ID );
+            if ( function_exists( 'get_fields' ) ) {
+                $fields = get_fields( $post->ID );
+                if ( $fields ) {
+                    $item['acf'] = $fields;
+                }
             }
             $data[] = $item;
         }
@@ -386,8 +503,12 @@ class LightWork_WP_Plugin {
             $query = new WP_Query( $args );
             while ( $query->have_posts() ) {
                 $query->the_post();
-                if ( function_exists( 'update_field' ) ) {
-                    update_field( 'subtitle', 'Updated via cron', get_the_ID() );
+                if ( function_exists( 'update_field' ) && ! empty( $cpt['acf_fields'] ) ) {
+                    foreach ( $cpt['acf_fields'] as $field ) {
+                        if ( ! empty( $field['name'] ) ) {
+                            update_field( $field['name'], 'Updated via cron', get_the_ID() );
+                        }
+                    }
                 }
             }
             wp_reset_postdata();


### PR DESCRIPTION
## Summary
- allow defining ACF fields for each CPT
- support menu icon, rewrite slug and hierarchical options
- return all ACF fields in REST output
- document new features

## Testing
- `php -l lightwork-wp-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590b3d1dc0832f95454b4fad41dd31