### PR TITLE
Enhance CPT creation UI and quick edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Descrizione
 
-Il **LightWork-WP-Plugin** per WordPress permette di creare, configurare e gestire facilmente **Custom Post Types (CTP)** personalizzati. Grazie all'integrazione con **Advanced Custom Fields (ACF)**, il plugin offre una soluzione potente sia per gli utenti avanzati che per quelli meno esperti. Consente di creare CTP avanzati, associarvi campi personalizzati, template dinamici e fornisce anche rotte REST per una gestione completamente automatizzata dei dati. Dalla versione 0.3 è possibile aggiungere o rimuovere i campi ACF direttamente dalla schermata di modifica del CTP.
+Il **LightWork-WP-Plugin** per WordPress permette di creare, configurare e gestire facilmente **Custom Post Types (CTP)** personalizzati. Grazie all'integrazione con **Advanced Custom Fields (ACF)**, il plugin offre una soluzione potente sia per gli utenti avanzati che per quelli meno esperti. Consente di creare CTP avanzati, associarvi campi personalizzati, template dinamici e fornisce anche rotte REST per una gestione completamente automatizzata dei dati. Dalla versione 0.3.1 è possibile gestire i campi ACF anche dalla "modifica rapida" e scegliere se il CPT si comporta come pagina o articolo.
 
 Il plugin è progettato per essere facilmente configurabile tramite un **wizard di amministrazione**, con una gestione automatica delle modifiche dei CTP, senza compromettere la performance del sito. Le rotte REST personalizzate permettono una completa personalizzazione delle query, rendendo il plugin ideale per sviluppatori avanzati e per l'uso su siti con un elevato volume di contenuti.
 
@@ -17,6 +17,7 @@ Il plugin è progettato per essere facilmente configurabile tramite un **wizard 
 - Gestione completa dei CTP con tutte le opzioni di configurazione, inclusa la visibilità e i permessi.
 - Possibilità di definire icona del menu, slug di riscrittura e struttura gerarchica del CTP direttamente dall'interfaccia.
 - I campi ACF possono essere aggiunti o rimossi dal form di modifica del CTP e la modifica si applica a tutti gli elementi esistenti.
+- I campi ACF possono essere modificati rapidamente tramite la "modifica rapida" nella lista delle istanze del CTP.
 - I CTP vengono visualizzati e gestiti nel backend di WordPress in modo intuitivo.
 
 ### 2. Integrazione con ACF (Advanced Custom Fields)


### PR DESCRIPTION
## Summary
- redesign CPT creation form with ACF toggle and option descriptions
- allow choosing page-like behaviour when creating CPTs
- add quick edit support for ACF fields
- document quick edit feature in README
- bump plugin version to 0.3.1

## Testing
- `php -l lightwork-wp-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68591455c6f0832f84822fd7e2185b52