### PR TITLE
Setup release packaging and deploy plugin with Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore release archives
+Release/*.tar.gz
+Release/*.zip
+
+# Ignore volumes for docker
+wordpress
+node_modules
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM wordpress:latest
+
+# Copy plugin archive into image
+COPY Release/*.tar.gz /tmp/plugin.tar.gz
+
+# Extract plugin
+RUN mkdir -p /usr/src/wordpress/wp-content/plugins/lightwork-plugin \
+    && tar -xzf /tmp/plugin.tar.gz -C /usr/src/wordpress/wp-content/plugins/lightwork-plugin --strip-components=1 \
+    && rm /tmp/plugin.tar.gz
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# LightWork WP Plugin Development
+
+## Building a Release
+
+Run `./build_release.sh` to create a tarball of the plugin. The archive will be placed in the `Release/` directory and named according to the version defined inside `lightwork-wp-plugin.php`.
+
+## Local Testing with Docker
+
+1. Build the plugin archive with `./build_release.sh`.
+2. Start the environment with `docker-compose up --build`.
+3. WordPress will be available on [http://localhost:8080](http://localhost:8080) with the plugin already installed.
+

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RELEASE_DIR="$SCRIPT_DIR/Release"
+PLUGIN_DIR="$SCRIPT_DIR/Lightwork-plugin"
+
+mkdir -p "$RELEASE_DIR"
+
+VERSION=$(grep -Eo "Version:\s*[0-9.]+" "$PLUGIN_DIR/lightwork-wp-plugin.php" | awk '{print $2}')
+if [ -z "$VERSION" ]; then
+    VERSION="latest"
+fi
+
+ARCHIVE_NAME="lightwork-plugin-${VERSION}.tar.gz"
+
+# Create archive
+
+tar -czf "$RELEASE_DIR/$ARCHIVE_NAME" -C "$PLUGIN_DIR" .
+
+echo "Created $RELEASE_DIR/$ARCHIVE_NAME"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   wordpress:
-    image: wordpress
+    build: .
     restart: always
     ports:
       - 8080:80


### PR DESCRIPTION
## Summary
- add packaging script to create tar archive in `Release/`
- place plugin archive into Docker image
- update compose file to build custom image
- add basic development readme
- keep release files out of git with `.gitignore`

## Testing
- `./build_release.sh`
- `docker --version` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711488b8d0832fbab3c096fc559219