### PR TITLE
Fix zip build and live plugin volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Ignore release archives
-Release/*.tar.gz
 Release/*.zip
 
 # Ignore volumes for docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 FROM wordpress:latest
 
+# Install unzip for extracting the plugin
+RUN apt-get update \
+    && apt-get install -y unzip \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy plugin archive into image
-COPY Release/*.tar.gz /tmp/plugin.tar.gz
+COPY Release/*.zip /tmp/plugin.zip
 
 # Extract plugin
 RUN mkdir -p /usr/src/wordpress/wp-content/plugins/lightwork-plugin \
-    && tar -xzf /tmp/plugin.tar.gz -C /usr/src/wordpress/wp-content/plugins/lightwork-plugin --strip-components=1 \
-    && rm /tmp/plugin.tar.gz
+    && unzip /tmp/plugin.zip -d /usr/src/wordpress/wp-content/plugins/lightwork-plugin \
+    && rm /tmp/plugin.zip
 

--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ Il workflow genererà il pacchetto `lightwork-wp-plugin.zip` e lo allegherà all
 
 ## Creazione di una Release
 
-Esegui `./build_release.sh` per creare un archivio tarball del plugin. L’archivio verrà salvato nella directory `Release/` e sarà nominato in base alla versione definita all’interno di `lightwork-wp-plugin.php`.
+Esegui `./build_release.sh` per creare un archivio **zip** del plugin. L’archivio verrà salvato nella directory `Release/` e sarà nominato in base alla versione definita all’interno di `lightwork-wp-plugin.php`.
 
 ## Test Locale con Docker
 
-1. Crea l’archivio del plugin con `./build_release.sh`.
-2. Avvia l’ambiente con `docker-compose up --build`.
+1. Avvia l’ambiente con `docker-compose up --build`.
+2. Grazie al volume definito in `docker-compose.yml`, ogni modifica nella cartella `Lightwork-plugin` viene applicata in tempo reale all’interno di WordPress.
 3. WordPress sarà disponibile su [http://localhost:8080](http://localhost:8080) con il plugin già installato.

--- a/build_release.sh
+++ b/build_release.sh
@@ -12,11 +12,10 @@ if [ -z "$VERSION" ]; then
     VERSION="latest"
 fi
 
-ARCHIVE_NAME="lightwork-plugin-${VERSION}.tar.gz"
+ARCHIVE_NAME="lightwork-plugin-${VERSION}.zip"
 
 # Create archive
-
-tar -czf "$RELEASE_DIR/$ARCHIVE_NAME" -C "$PLUGIN_DIR" .
+(cd "$PLUGIN_DIR" && zip -r "$RELEASE_DIR/$ARCHIVE_NAME" .)
 
 echo "Created $RELEASE_DIR/$ARCHIVE_NAME"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       WORDPRESS_DB_NAME: exampledb
     volumes:
       - wordpress:/var/www/html
+      - ./Lightwork-plugin:/var/www/html/wp-content/plugins/lightwork-plugin
 
   db:
     image: mysql:8.0


### PR DESCRIPTION
## Summary
- package plugin as a zip instead of tar
- install `unzip` in Dockerfile
- mount the plugin source directory in docker-compose
- update release script
- document new workflow
- clean `.gitignore`

## Testing
- `bash build_release.sh`
- `bash -n build_release.sh`

------
https://chatgpt.com/codex/tasks/task_e_68712079f8b0832f98452ecd50d6a0b3