### PR TITLE
Integrate template editor with Gutenberg

### DIFF
--- a/Lightwork-plugin/assets/editor-addon.css
+++ b/Lightwork-plugin/assets/editor-addon.css
@@ -1,0 +1,3 @@
+#lw-field-overlay{box-sizing:border-box}
+#lw-field-overlay .lw-field{background:#fff}
+.lw-highlight{outline:2px dashed red;}

--- a/Lightwork-plugin/assets/editor-addon.js
+++ b/Lightwork-plugin/assets/editor-addon.js
@@ -1,0 +1,51 @@
+(function($){
+    if(typeof lwFieldData === 'undefined') return;
+    $(function(){
+        var overlay = $('<div id="lw-field-overlay"></div>').css({
+            position:'fixed',top:0,left:0,right:0,bottom:0,background:'rgba(0,0,0,0.5)',
+            'z-index':100000,display:'none',padding:'40px',overflow:'auto'
+        });
+        var list = $('<div id="lw-field-list"></div>').css({background:'#fff',padding:'20px'});
+        overlay.append(list);
+        $('body').append(overlay);
+
+        $('<button id="lw-field-button" class="button">'+lwFieldData.label+'</button>').appendTo('.edit-post-header-toolbar').on('click',function(){
+            overlay.toggle();
+            if(overlay.is(':visible')){ buildList(); makeDroppable(); }
+        });
+
+        function buildList(){
+            list.empty();
+            lwFieldData.fields.forEach(function(f){
+                if(!lwFieldData.mapping[f.name]){
+                    var item = $('<div class="lw-field"></div>').text(f.label).attr('data-field',f.name).css({border:'1px solid #ccc',padding:'5px',margin:'5px',cursor:'move'});
+                    list.append(item);
+                    item.draggable({helper:'clone'});
+                }
+            });
+        }
+
+        function makeDroppable(){
+            $('.editor-block-list__block').each(function(){
+                var block = $(this);
+                if(block.data('lw-droppable')) return;
+                block.data('lw-droppable',true);
+                block.droppable({
+                    hoverClass:'lw-highlight',
+                    drop:function(e,ui){
+                        var field = ui.draggable.data('field');
+                        if(!field) return;
+                        var id = block.attr('id');
+                        if(!id){
+                            id = 'lw-'+Math.random().toString(36).substr(2,8);
+                            block.attr('id',id);
+                        }
+                        $.post(lwFieldData.ajaxurl,{action:'lw_update_mapping',slug:lwFieldData.slug,field:field,selector:'#'+id,_ajax_nonce:lwFieldData.nonce});
+                        ui.draggable.remove();
+                        lwFieldData.mapping[field] = '#'+id;
+                    }
+                });
+            });
+        }
+    });
+})(jQuery);

--- a/Lightwork-plugin/lightwork-wp-plugin.php
+++ b/Lightwork-plugin/lightwork-wp-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: LightWork WP Plugin
  * Description: Gestione dei Custom Post Types integrata con ACF e REST API.
- * Version: 0.3.5
+ * Version: 0.3.6
  * Author: LightWork
  * License: GPLv2 or later
  */

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Il plugin è progettato per essere facilmente configurabile tramite un **wizard 
 - Dalla versione 0.3.3 l'interfaccia di creazione dei CTP include un selettore grafico delle icone del menu.
 - Dalla versione 0.3.4 la procedura di creazione è più semplice: alcune opzioni ridondanti sono state rimosse e, se si collega un template, il CPT diventa automaticamente gerarchico.
 - Dalla versione 0.3.5 il pannello di creazione adotta uno stile più moderno per una migliore usabilità.
+- Dalla versione 0.3.6 il Template Editor è integrato nell'editor di Gutenberg con un pulsante che consente di trascinare i campi ACF non mappati direttamente sugli elementi della pagina.
 
 ### 4. Rotte REST per il recupero dei dati
 


### PR DESCRIPTION
## Summary
- expose Template Editor on CPT pages via metabox
- show only unmapped ACF fields in the editor
- allow Ajax updates of field mappings
- enqueue new drag and drop mapping script in the block editor
- bump plugin version to 0.3.6 and document feature

## Testing
- `php -l Lightwork-plugin/includes/class-template-editor.php`
- `php -l Lightwork-plugin/includes/class-cpt-system.php`


------
https://chatgpt.com/codex/tasks/task_e_6874b1849980832fbf76128d568a61e4