### PR TITLE
Implement sandbox editor

### DIFF
--- a/Lightwork-plugin/assets/sandbox.css
+++ b/Lightwork-plugin/assets/sandbox.css
@@ -1,0 +1,7 @@
+#lw-sandbox{display:flex;gap:10px;height:600px}
+#lw-preview{flex:1;overflow:auto;border:1px solid #ccd0d4;}
+#lw-preview iframe{width:100%;height:100%;border:0;}
+#lw-editors{flex:1;display:flex;flex-direction:column;min-width:300px;}
+#lw-html{flex:1;height:200px;font-family:monospace;}
+#lw-sub{display:flex;flex:1;gap:5px;}
+#lw-sub textarea{flex:1;font-family:monospace;}

--- a/Lightwork-plugin/assets/sandbox.js
+++ b/Lightwork-plugin/assets/sandbox.js
@@ -1,0 +1,44 @@
+jQuery(function($){
+    function updatePreview(){
+        var html = $('#lw-html').val();
+        var css = $('#lw-css').val();
+        var js = $('#lw-js').val();
+        var doc = $('#lw-preview iframe')[0].contentDocument;
+        doc.open();
+        doc.write(html + '<style>'+css+'</style><script>'+js+'<\/script>');
+        doc.close();
+    }
+    $('#lw-run').on('click', function(e){
+        e.preventDefault();
+        updatePreview();
+    });
+    $('#lw-save').on('click', function(e){
+        e.preventDefault();
+        $.post(lwSandbox.ajaxurl, {
+            action:'lw_save_sandbox',
+            nonce:lwSandbox.nonce,
+            html:$('#lw-html').val(),
+            css:$('#lw-css').val(),
+            js:$('#lw-js').val()
+        }, function(){
+            alert('Saved');
+        });
+    });
+    $('#lw-preview iframe').on('load', function(){
+        var doc = this.contentDocument;
+        $(doc).on('click', '*', function(ev){
+            ev.preventDefault();
+            var html = $('#lw-html').val();
+            var tag = this.outerHTML.split(/\n/)[0];
+            var idx = html.indexOf(tag);
+            if(idx>=0){
+                $('#lw-html')[0].setSelectionRange(idx, idx);
+                $('#lw-html')[0].focus();
+            }
+            if(this.hasAttribute('style')){
+                $('#lw-css').val(this.getAttribute('style'));
+            }
+        });
+    });
+    updatePreview();
+});

--- a/Lightwork-plugin/includes/class-lightwork-wp-plugin.php
+++ b/Lightwork-plugin/includes/class-lightwork-wp-plugin.php
@@ -14,6 +14,9 @@ class LightWork_WP_Plugin {
     /** @var LightWork_CPT_System */
     private $cpt_system;
 
+    /** @var LightWork_Sandbox_Editor */
+    private $sandbox_editor;
+
     public static function instance() {
         if ( null === self::$instance ) {
             self::$instance = new self();
@@ -23,11 +26,13 @@ class LightWork_WP_Plugin {
 
     private function __construct() {
         $this->template_editor = new LightWork_Template_Editor();
+        $this->sandbox_editor = new LightWork_Sandbox_Editor();
         $this->acf_system      = new LightWork_ACF_System();
         $this->cpt_system      = new LightWork_CPT_System( $this->acf_system, $this->template_editor );
 
         add_action( 'init', [ $this->cpt_system, 'register_saved_cpts' ] );
         add_action( 'admin_menu', [ $this->cpt_system, 'register_admin_menu' ] );
+        add_action( 'admin_menu', [ $this->sandbox_editor, 'register_page' ] );
         add_action( 'admin_enqueue_scripts', [ $this->cpt_system, 'enqueue_assets' ] );
         add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
         add_action( self::CRON_HOOK, [ $this, 'batch_update' ] );

--- a/Lightwork-plugin/includes/class-sandbox-editor.php
+++ b/Lightwork-plugin/includes/class-sandbox-editor.php
@@ -1,0 +1,97 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LightWork_Sandbox_Editor {
+    const OPTION_NAME = 'lw_sandbox_html';
+
+    public function register_page() {
+        add_submenu_page(
+            null,
+            __( 'Sandbox Editor', 'lightwork-wp-plugin' ),
+            __( 'Sandbox Editor', 'lightwork-wp-plugin' ),
+            'manage_options',
+            'lightwork-sandbox-editor',
+            [ $this, 'render_page' ]
+        );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'wp_ajax_lw_save_sandbox', [ $this, 'ajax_save' ] );
+    }
+
+    public function enqueue_assets( $hook ) {
+        if ( strpos( $hook, 'lightwork-sandbox-editor' ) === false ) {
+            return;
+        }
+        wp_enqueue_script(
+            'lw-sandbox',
+            plugins_url( 'assets/sandbox.js', dirname( __DIR__ ) . '/lightwork-wp-plugin.php' ),
+            [ 'jquery' ],
+            '0.3.6',
+            true
+        );
+        wp_enqueue_style(
+            'lw-sandbox',
+            plugins_url( 'assets/sandbox.css', dirname( __DIR__ ) . '/lightwork-wp-plugin.php' ),
+            [],
+            '0.3.6'
+        );
+        wp_localize_script( 'lw-sandbox', 'lwSandbox', [
+            'ajaxurl' => admin_url( 'admin-ajax.php' ),
+            'nonce'   => wp_create_nonce( 'lw_sandbox_save' ),
+        ] );
+    }
+
+    public function render_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        $html = get_option( self::OPTION_NAME, '<p>Hello World</p>' );
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Sandbox Editor', 'lightwork-wp-plugin' ); ?></h1>
+            <div id="lw-sandbox">
+                <div id="lw-preview">
+                    <iframe></iframe>
+                </div>
+                <div id="lw-editors">
+                    <textarea id="lw-html" placeholder="HTML"><?php echo esc_textarea( $html ); ?></textarea>
+                    <div id="lw-sub">
+                        <textarea id="lw-css" placeholder="CSS"></textarea>
+                        <textarea id="lw-js" placeholder="JS"></textarea>
+                    </div>
+                    <p>
+                        <button id="lw-run" class="button button-primary"><?php esc_html_e( 'Preview', 'lightwork-wp-plugin' ); ?></button>
+                        <button id="lw-save" class="button"><?php esc_html_e( 'Save', 'lightwork-wp-plugin' ); ?></button>
+                    </p>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+
+    public function ajax_save() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        check_ajax_referer( 'lw_sandbox_save', 'nonce' );
+        $html = wp_unslash( $_POST['html'] ?? '' );
+        $css  = wp_unslash( $_POST['css'] ?? '' );
+        $js   = wp_unslash( $_POST['js'] ?? '' );
+
+        $html = preg_replace( '#</?(head|body)[^>]*>#i', '', $html );
+        $html = wp_kses_post( $html );
+        $css  = sanitize_textarea_field( $css );
+        $js   = sanitize_textarea_field( $js );
+
+        $final = $html;
+        if ( $css ) {
+            $final .= '<style>' . $css . '</style>';
+        }
+        if ( $js ) {
+            $final .= '<script>' . $js . '</script>';
+        }
+        update_option( self::OPTION_NAME, $final );
+        wp_send_json_success();
+    }
+}

--- a/Lightwork-plugin/lightwork-wp-plugin.php
+++ b/Lightwork-plugin/lightwork-wp-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: LightWork WP Plugin
  * Description: Gestione dei Custom Post Types integrata con ACF e REST API.
- * Version: 0.3.5
+ * Version: 0.3.6
  * Author: LightWork
  * License: GPLv2 or later
  */
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/includes/class-template-editor.php';
 require_once __DIR__ . '/includes/class-acf-system.php';
 require_once __DIR__ . '/includes/class-cpt-system.php';
+require_once __DIR__ . '/includes/class-sandbox-editor.php';
 require_once __DIR__ . '/includes/class-lightwork-wp-plugin.php';
 
 function lightwork_wp_plugin_main() {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Il plugin è progettato per essere facilmente configurabile tramite un **wizard 
 - Dalla versione 0.3.3 l'interfaccia di creazione dei CTP include un selettore grafico delle icone del menu.
 - Dalla versione 0.3.4 la procedura di creazione è più semplice: alcune opzioni ridondanti sono state rimosse e, se si collega un template, il CPT diventa automaticamente gerarchico.
 - Dalla versione 0.3.5 il pannello di creazione adotta uno stile più moderno per una migliore usabilità.
+- Dalla versione 0.3.6 è disponibile un **Sandbox Editor** per modificare HTML, CSS e JS con anteprima in tempo reale.
 
 ### 4. Rotte REST per il recupero dei dati
 


### PR DESCRIPTION
## Summary
- bump plugin version to 0.3.6
- add Sandbox Editor page with HTML/CSS/JS editors
- store page markup inline when saved
- document new feature in README

## Testing
- `php -l Lightwork-plugin/includes/class-sandbox-editor.php`
- `php -l Lightwork-plugin/includes/class-lightwork-wp-plugin.php`
- `php -l Lightwork-plugin/lightwork-wp-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_6874be2ea154832f974be8f9fb79ff22