### PR TITLE
Implement sandbox ACF drag support

### DIFF
--- a/Lightwork-plugin/assets/sandbox.css
+++ b/Lightwork-plugin/assets/sandbox.css
@@ -1,0 +1,10 @@
+#lw-sandbox{display:flex;gap:10px;height:600px}
+#lw-preview{flex:1;overflow:auto;border:1px solid #ccd0d4;}
+#lw-preview iframe{width:100%;height:100%;border:0;}
+#lw-editors{flex:1;display:flex;flex-direction:column;min-width:300px;}
+#lw-html{flex:1;height:200px;font-family:monospace;}
+#lw-sub{display:flex;flex:1;gap:5px;}
+#lw-sub textarea{flex:1;font-family:monospace;}
+#lw-fields{margin-top:10px;}
+#lw-fields .lw-field{border:1px solid #ccc;padding:5px;margin-bottom:5px;cursor:move;background:#fff;}
+#lw-preview .lw-highlight{outline:2px dashed red;}

--- a/Lightwork-plugin/assets/sandbox.js
+++ b/Lightwork-plugin/assets/sandbox.js
@@ -1,0 +1,66 @@
+jQuery(function($){
+    $('.lw-field').draggable({helper:'clone'});
+    function attachDroppable(){
+        var doc = $('#lw-preview iframe')[0].contentDocument;
+        $(doc).find('*').each(function(){
+            try{ $(this).droppable('destroy'); }catch(e){}
+            $(this).droppable({
+                hoverClass:'lw-highlight',
+                drop:function(e,ui){
+                    var field = $(ui.draggable).data('field');
+                    if(field){
+                        this.setAttribute('id', field);
+                        var clone = $(doc.body).clone();
+                        clone.find('style,script').remove();
+                        $('#lw-html').val(clone.html());
+                        updatePreview();
+                    }
+                }
+            });
+        });
+    }
+
+    function updatePreview(){
+        var html = $('#lw-html').val();
+        var css = $('#lw-css').val();
+        var js = $('#lw-js').val();
+        var doc = $('#lw-preview iframe')[0].contentDocument;
+        doc.open();
+        doc.write(html + '<style>'+css+'</style><script>'+js+'<\/script>');
+        doc.close();
+        attachDroppable();
+    }
+    $('#lw-run').on('click', function(e){
+        e.preventDefault();
+        updatePreview();
+    });
+    $('#lw-save').on('click', function(e){
+        e.preventDefault();
+        $.post(lwSandbox.ajaxurl, {
+            action:'lw_save_sandbox',
+            nonce:lwSandbox.nonce,
+            html:$('#lw-html').val(),
+            css:$('#lw-css').val(),
+            js:$('#lw-js').val()
+        }, function(){
+            alert('Saved');
+        });
+    });
+    $('#lw-preview iframe').on('load', function(){
+        var doc = this.contentDocument;
+        $(doc).on('click', '*', function(ev){
+            ev.preventDefault();
+            var html = $('#lw-html').val();
+            var tag = this.outerHTML.split(/\n/)[0];
+            var idx = html.indexOf(tag);
+            if(idx>=0){
+                $('#lw-html')[0].setSelectionRange(idx, idx);
+                $('#lw-html')[0].focus();
+            }
+            if(this.hasAttribute('style')){
+                $('#lw-css').val(this.getAttribute('style'));
+            }
+        });
+    });
+    updatePreview();
+});

--- a/Lightwork-plugin/includes/class-cpt-system.php
+++ b/Lightwork-plugin/includes/class-cpt-system.php
@@ -172,7 +172,7 @@ class LightWork_CPT_System {
             $delete = wp_nonce_url( admin_url( 'admin.php?page=lightwork-wp-plugin&action=delete&slug=' . $cpt['slug'] ), 'lw_delete_cpt_' . $cpt['slug'] );
             $template = '';
             if ( ! empty( $cpt['template_page'] ) ) {
-                $tlink = admin_url( 'admin.php?page=lightwork-template-editor&slug=' . $cpt['slug'] );
+                $tlink = admin_url( 'admin.php?page=lightwork-sandbox-editor&slug=' . $cpt['slug'] );
                 $template = ' | <a href="' . esc_url( $tlink ) . '">' . esc_html__( 'Template', 'lightwork-wp-plugin' ) . '</a>';
             }
             echo '<tr>';
@@ -455,7 +455,7 @@ class LightWork_CPT_System {
 
         add_settings_error( 'lightwork', 'success', $message, 'updated' );
         if ( $use_template ) {
-            $link = admin_url( 'admin.php?page=lightwork-template-editor&slug=' . $slug );
+            $link = admin_url( 'admin.php?page=lightwork-sandbox-editor&slug=' . $slug );
             add_settings_error( 'lightwork', 'template', sprintf( __( 'Configure the template <a href="%s">here</a>.', 'lightwork-wp-plugin' ), esc_url( $link ) ), 'updated' );
         }
     }

--- a/Lightwork-plugin/includes/class-lightwork-wp-plugin.php
+++ b/Lightwork-plugin/includes/class-lightwork-wp-plugin.php
@@ -14,6 +14,9 @@ class LightWork_WP_Plugin {
     /** @var LightWork_CPT_System */
     private $cpt_system;
 
+    /** @var LightWork_Sandbox_Editor */
+    private $sandbox_editor;
+
     public static function instance() {
         if ( null === self::$instance ) {
             self::$instance = new self();
@@ -23,11 +26,13 @@ class LightWork_WP_Plugin {
 
     private function __construct() {
         $this->template_editor = new LightWork_Template_Editor();
+        $this->sandbox_editor = new LightWork_Sandbox_Editor();
         $this->acf_system      = new LightWork_ACF_System();
         $this->cpt_system      = new LightWork_CPT_System( $this->acf_system, $this->template_editor );
 
         add_action( 'init', [ $this->cpt_system, 'register_saved_cpts' ] );
         add_action( 'admin_menu', [ $this->cpt_system, 'register_admin_menu' ] );
+        add_action( 'admin_menu', [ $this->sandbox_editor, 'register_page' ] );
         add_action( 'admin_enqueue_scripts', [ $this->cpt_system, 'enqueue_assets' ] );
         add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
         add_action( self::CRON_HOOK, [ $this, 'batch_update' ] );

--- a/Lightwork-plugin/includes/class-sandbox-editor.php
+++ b/Lightwork-plugin/includes/class-sandbox-editor.php
@@ -1,0 +1,150 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LightWork_Sandbox_Editor {
+    const OPTION_NAME = 'lw_sandbox_html';
+    const PAGE_OPTION = 'lw_sandbox_page_id';
+
+    public function register_page() {
+        add_submenu_page(
+            'lightwork-wp-plugin',
+            __( 'Sandbox Editor', 'lightwork-wp-plugin' ),
+            __( 'Sandbox Editor', 'lightwork-wp-plugin' ),
+            'manage_options',
+            'lightwork-sandbox-editor',
+            [ $this, 'render_page' ]
+        );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'wp_ajax_lw_save_sandbox', [ $this, 'ajax_save' ] );
+    }
+
+    public function enqueue_assets( $hook ) {
+        if ( strpos( $hook, 'lightwork-sandbox-editor' ) === false ) {
+            return;
+        }
+        wp_enqueue_script(
+            'lw-sandbox',
+            plugins_url( 'assets/sandbox.js', dirname( __DIR__ ) . '/lightwork-wp-plugin.php' ),
+            [ 'jquery', 'jquery-ui-draggable', 'jquery-ui-droppable' ],
+            '0.3.8',
+            true
+        );
+        wp_enqueue_style(
+            'lw-sandbox',
+            plugins_url( 'assets/sandbox.css', dirname( __DIR__ ) . '/lightwork-wp-plugin.php' ),
+            [],
+            '0.3.8'
+        );
+        $fields = [];
+        if ( isset( $_GET['slug'] ) ) {
+            $slug = sanitize_key( $_GET['slug'] );
+            $cpts = get_option( LightWork_WP_Plugin::OPTION_CPTS, [] );
+            foreach ( $cpts as $cpt ) {
+                if ( $cpt['slug'] === $slug && ! empty( $cpt['acf_fields'] ) ) {
+                    foreach ( $cpt['acf_fields'] as $f ) {
+                        $name = sanitize_key( $f['name'] );
+                        $label = sanitize_text_field( $f['label'] );
+                        $fields[ $name ] = $label ?: $name;
+                    }
+                    break;
+                }
+            }
+        }
+        wp_localize_script( 'lw-sandbox', 'lwSandbox', [
+            'ajaxurl' => admin_url( 'admin-ajax.php' ),
+            'nonce'   => wp_create_nonce( 'lw_sandbox_save' ),
+            'fields'  => $fields,
+        ] );
+    }
+
+    public function render_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        $html   = get_option( self::OPTION_NAME, '<p>Hello World</p>' );
+        $fields = [];
+        if ( isset( $_GET['slug'] ) ) {
+            $slug  = sanitize_key( $_GET['slug'] );
+            $cpts  = get_option( LightWork_WP_Plugin::OPTION_CPTS, [] );
+            foreach ( $cpts as $cpt ) {
+                if ( $cpt['slug'] === $slug && ! empty( $cpt['acf_fields'] ) ) {
+                    $fields = $cpt['acf_fields'];
+                    break;
+                }
+            }
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Sandbox Editor', 'lightwork-wp-plugin' ); ?></h1>
+            <div id="lw-sandbox">
+                <div id="lw-preview">
+                    <iframe></iframe>
+                </div>
+                <div id="lw-editors">
+                    <textarea id="lw-html" placeholder="HTML"><?php echo esc_textarea( $html ); ?></textarea>
+                    <div id="lw-sub">
+                        <textarea id="lw-css" placeholder="CSS"></textarea>
+                        <textarea id="lw-js" placeholder="JS"></textarea>
+                    </div>
+                    <p>
+                        <button id="lw-run" class="button button-primary"><?php esc_html_e( 'Preview', 'lightwork-wp-plugin' ); ?></button>
+                        <button id="lw-save" class="button"><?php esc_html_e( 'Save', 'lightwork-wp-plugin' ); ?></button>
+                    </p>
+                    <?php if ( $fields ) : ?>
+                    <div id="lw-fields">
+                        <h2><?php esc_html_e( 'ACF Fields', 'lightwork-wp-plugin' ); ?></h2>
+                        <?php foreach ( $fields as $f ) : $name = esc_attr( $f['name'] ); ?>
+                            <div class="lw-field" data-field="<?php echo $name; ?>"><?php echo esc_html( $f['label'] ); ?></div>
+                        <?php endforeach; ?>
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+
+    public function ajax_save() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        check_ajax_referer( 'lw_sandbox_save', 'nonce' );
+        $html = wp_unslash( $_POST['html'] ?? '' );
+        $css  = wp_unslash( $_POST['css'] ?? '' );
+        $js   = wp_unslash( $_POST['js'] ?? '' );
+
+        $html = preg_replace( '#</?(head|body)[^>]*>#i', '', $html );
+        $html = wp_kses_post( $html );
+        $css  = sanitize_textarea_field( $css );
+        $js   = sanitize_textarea_field( $js );
+
+        $final = $html;
+        if ( $css ) {
+            $final .= '<style>' . $css . '</style>';
+        }
+        if ( $js ) {
+            $final .= '<script>' . $js . '</script>';
+        }
+        update_option( self::OPTION_NAME, $final );
+
+        $page_id = (int) get_option( self::PAGE_OPTION );
+        $page_data = [
+            'post_title'   => 'Sandbox Template',
+            'post_status'  => 'draft',
+            'post_type'    => 'page',
+            'post_content' => $final,
+            'post_name'    => 'lw-sandbox-template',
+        ];
+        if ( $page_id && get_post( $page_id ) ) {
+            $page_data['ID'] = $page_id;
+            wp_update_post( $page_data );
+        } else {
+            $page_id = wp_insert_post( $page_data );
+            update_option( self::PAGE_OPTION, $page_id );
+        }
+
+        wp_send_json_success();
+    }
+}

--- a/Lightwork-plugin/includes/class-template-editor.php
+++ b/Lightwork-plugin/includes/class-template-editor.php
@@ -22,103 +22,12 @@ class LightWork_Template_Editor {
             return;
         }
 
-        wp_enqueue_script( 'jquery-ui-draggable' );
-        wp_enqueue_script( 'jquery-ui-droppable' );
-
         $slug = isset( $_GET['slug'] ) ? sanitize_key( $_GET['slug'] ) : '';
-        $cpts = get_option( LightWork_WP_Plugin::OPTION_CPTS, [] );
-        $cpt  = null;
-        foreach ( $cpts as $item ) {
-            if ( $item['slug'] === $slug ) {
-                $cpt = $item;
-                break;
-            }
+        $url  = admin_url( 'admin.php?page=lightwork-sandbox-editor' );
+        if ( $slug ) {
+            $url = add_query_arg( 'slug', $slug, $url );
         }
-        if ( ! $cpt || empty( $cpt['template_page'] ) ) {
-            echo '<div class="wrap"><h1>' . esc_html__( 'No template configured.', 'lightwork-wp-plugin' ) . '</h1></div>';
-            return;
-        }
-
-        $page_id   = $cpt['template_page'];
-        $acf_fields = $cpt['acf_fields'] ?? [];
-        $option     = self::OPTION_PREFIX . $slug;
-        $mapping    = get_option( $option, [] );
-
-        if ( isset( $_POST['lw-save-template'] ) && check_admin_referer( 'lw_save_template_' . $slug ) ) {
-            $mapping = [];
-            foreach ( (array) ( $_POST['lw-mapping'] ?? [] ) as $key => $sel ) {
-                $mapping[ sanitize_key( $key ) ] = sanitize_text_field( $sel );
-            }
-            $missing = [];
-            foreach ( $acf_fields as $field ) {
-                if ( empty( $mapping[ $field['name'] ] ) ) {
-                    $missing[] = $field['name'];
-                }
-            }
-            if ( $missing ) {
-                add_settings_error( 'lightwork', 'missing', __( 'Map all fields before saving.', 'lightwork-wp-plugin' ) );
-            } else {
-                update_option( $option, $mapping );
-                add_settings_error( 'lightwork', 'saved', __( 'Template saved.', 'lightwork-wp-plugin' ), 'updated' );
-            }
-        }
-
-        ?>
-        <div class="wrap">
-            <h1><?php esc_html_e( 'Template Editor', 'lightwork-wp-plugin' ); ?></h1>
-            <?php settings_errors( 'lightwork' ); ?>
-            <div id="lw-template-editor" style="display:flex;gap:20px;">
-                <div id="lw-template-preview" style="flex:1;">
-                    <iframe src="<?php echo esc_url( get_permalink( $page_id ) ); ?>" style="width:100%;height:500px;border:1px solid #ccc;"></iframe>
-                </div>
-                <div id="lw-template-fields" style="width:250px;">
-                    <form method="post">
-                        <?php wp_nonce_field( 'lw_save_template_' . $slug ); ?>
-                        <?php foreach ( $acf_fields as $field ) :
-                            $name  = esc_attr( $field['name'] );
-                            $label = esc_html( $field['label'] );
-                            $sel   = esc_attr( $mapping[ $name ] ?? '' ); ?>
-                            <div class="lw-field" data-field="<?php echo $name; ?>">
-                                <?php echo $label; ?>
-                                <input type="hidden" name="lw-mapping[<?php echo $name; ?>]" value="<?php echo $sel; ?>" />
-                            </div>
-                        <?php endforeach; ?>
-                        <p><input type="submit" name="lw-save-template" class="button button-primary" value="<?php esc_attr_e( 'Save Template', 'lightwork-wp-plugin' ); ?>" /></p>
-                    </form>
-                </div>
-            </div>
-        </div>
-        <style>
-        #lw-template-editor .lw-field{border:1px solid #ccc;padding:5px;margin-bottom:5px;cursor:move;background:#fff;}
-        #lw-template-preview .lw-highlight{outline:2px dashed red;}
-        </style>
-        <script>
-        jQuery(function($){
-            $('.lw-field').draggable({helper:'clone'});
-            $('#lw-template-preview iframe').on('load', function(){
-                var doc = this.contentWindow.document;
-                $(doc).find('*').each(function(){
-                    $(this).droppable({
-                        hoverClass:'lw-highlight',
-                        drop:function(e,ui){
-                            var selector = lwGetSelector(this);
-                            ui.draggable.find('input').val(selector);
-                        }
-                    });
-                });
-            });
-            function lwGetSelector(el){
-                var sel='';
-                while(el && el.nodeType===1 && !el.id){
-                    var idx=$(el).index();
-                    sel=el.tagName.toLowerCase()+(idx?':eq('+idx+')':'')+(sel?'>'+sel:'');
-                    el=el.parentElement;
-                }
-                if(el && el.id){ sel='#'+el.id+(sel?'>'+sel:''); }
-                return sel;
-            }
-        });
-        </script>
-        <?php
+        wp_safe_redirect( $url );
+        exit;
     }
 }

--- a/Lightwork-plugin/lightwork-wp-plugin.php
+++ b/Lightwork-plugin/lightwork-wp-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: LightWork WP Plugin
  * Description: Gestione dei Custom Post Types integrata con ACF e REST API.
- * Version: 0.3.5
+ * Version: 0.3.8
  * Author: LightWork
  * License: GPLv2 or later
  */
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/includes/class-template-editor.php';
 require_once __DIR__ . '/includes/class-acf-system.php';
 require_once __DIR__ . '/includes/class-cpt-system.php';
+require_once __DIR__ . '/includes/class-sandbox-editor.php';
 require_once __DIR__ . '/includes/class-lightwork-wp-plugin.php';
 
 function lightwork_wp_plugin_main() {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Il plugin è progettato per essere facilmente configurabile tramite un **wizard 
 - Dalla versione 0.3.3 l'interfaccia di creazione dei CTP include un selettore grafico delle icone del menu.
 - Dalla versione 0.3.4 la procedura di creazione è più semplice: alcune opzioni ridondanti sono state rimosse e, se si collega un template, il CPT diventa automaticamente gerarchico.
 - Dalla versione 0.3.5 il pannello di creazione adotta uno stile più moderno per una migliore usabilità.
+- Dalla versione 0.3.7 il **Sandbox Editor** salva il codice in una pagina "Sandbox Template" collegabile ai CPT.
+- Dalla versione 0.3.8 il Sandbox Editor permette di trascinare i campi ACF sull'anteprima assegnando l'ID corrispondente.
 
 ### 4. Rotte REST per il recupero dei dati
 


### PR DESCRIPTION
## Summary
- bump plugin version to 0.3.8
- support dragging ACF fields onto the Sandbox Editor preview
- show ACF field list in the Sandbox Editor
- link sandbox editor from CPT list and notices
- style sandbox editor field list
- redirect the old Template Editor page to the Sandbox Editor

## Testing
- `php -l Lightwork-plugin/includes/class-sandbox-editor.php`
- `php -l Lightwork-plugin/includes/class-lightwork-wp-plugin.php`
- `php -l Lightwork-plugin/includes/class-cpt-system.php`
- `php -l Lightwork-plugin/includes/class-template-editor.php`
- `php -l Lightwork-plugin/lightwork-wp-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6874be2ea154832f974be8f9fb79ff22